### PR TITLE
Fix timezone parsing and enable snoozing sent reminders

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -3,7 +3,7 @@ import { CONFIG } from './config.js';
 import { handleRemindContext } from './commands/remindContext.js';
 import { handleRemindersSlash } from './commands/remindersSlash.js';
 import { handleTimezoneSlash } from './commands/timezoneSlash.js';
-import { handlePresetButton, openCustomModal } from './interactions/buttons.js';
+import { handlePresetButton, handleSnoozeButton, openCustomModal } from './interactions/buttons.js';
 import { handleCustomModal } from './interactions/modals.js';
 import { startScheduler } from './scheduler.js';
 import { handleRemindSlash } from './commands/remindSlash.js';
@@ -39,6 +39,10 @@ client.on(Events.InteractionCreate, async (i) => {
       if (i.customId.startsWith('remind_preset:')) {
         const seconds = parseInt(i.customId.split(':')[1], 10);
         return handlePresetButton(i, seconds);
+      }
+      if (i.customId.startsWith('reminder_snooze:')) {
+        const [, id, seconds] = i.customId.split(':');
+        return handleSnoozeButton(i, parseInt(id, 10), parseInt(seconds, 10));
       }
       if (i.customId === 'remind_custom') return openCustomModal(i);
     }

--- a/src/time.ts
+++ b/src/time.ts
@@ -20,28 +20,13 @@ export function parseWhen(input: string, userId: string): { epoch: number; displ
     useForwardDate = false;
   }
   
-  // Create reference date in user's local time
-  const refDate = new Date(now.year, now.month - 1, now.day, now.hour, now.minute, now.second);
-  
-  // Parse with appropriate forward date setting
-  const parsed = chrono.parse(input, refDate, { forwardDate: useForwardDate });
+  // Use chrono-node with explicit timezone offset to parse text
+  const ref = { instant: now.toJSDate(), timezone: now.offset };
+  const parsed = chrono.parse(input, ref, { forwardDate: useForwardDate });
   if (!parsed?.length) return null;
-  
+
   const result = parsed[0];
-  const parsedDate = result.date();
-  
-  // Extract components
-  const year = parsedDate.getFullYear();
-  const month = parsedDate.getMonth() + 1;
-  const day = parsedDate.getDate();
-  const hour = parsedDate.getHours();
-  const minute = parsedDate.getMinutes();
-  const second = parsedDate.getSeconds();
-  
-  // Create target time in user's timezone
-  let targetTime = DateTime.fromObject({
-    year, month, day, hour, minute, second
-  }, { zone: tz });
+  let targetTime = DateTime.fromJSDate(result.date(), { zone: tz });
   
   // If we parsed "today" but got a past time, and forwardDate was disabled,
   // check if we should move it to tomorrow


### PR DESCRIPTION
## Summary
- keep sent reminders in the database and attach snooze buttons (1h/1d/1w)
- reschedule snoozed reminders using the user's timezone
- wire up snooze button handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad0e74ea008327a7e9b9d185004b2e