### PR TITLE
fix: serve monitoring UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ COPY package.json ./
 RUN npm i --omit=dev
 COPY --from=build /app/dist ./dist
 COPY .env.sample README.md app-manifest.json ./
+# Copy public assets for the monitoring UI
+COPY public ./public
 # Create the data directory and set up persistent volume for SQLite database
 RUN mkdir -p /data
 VOLUME ["/data"]


### PR DESCRIPTION
## Summary
- include `public` files in Docker image so shard status page loads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae783068b48327a417e77d1221f3a7