### PR TITLE
Display human-readable uptime on shard status page

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,24 @@
+function formatDuration(ms) {
+  const units = [
+    { label: 'year', ms: 1000 * 60 * 60 * 24 * 365 },
+    { label: 'month', ms: 1000 * 60 * 60 * 24 * 30 },
+    { label: 'week', ms: 1000 * 60 * 60 * 24 * 7 },
+    { label: 'day', ms: 1000 * 60 * 60 * 24 },
+    { label: 'hour', ms: 1000 * 60 * 60 },
+    { label: 'minute', ms: 1000 * 60 },
+    { label: 'second', ms: 1000 },
+  ];
+  const parts = [];
+  for (const unit of units) {
+    const value = Math.floor(ms / unit.ms);
+    if (value > 0) {
+      parts.push(`${value} ${unit.label}${value !== 1 ? 's' : ''}`);
+      ms -= value * unit.ms;
+    }
+  }
+  return parts.length ? parts.join(', ') : '0 seconds';
+}
+
 async function load() {
   const res = await fetch('/api/status');
   const data = await res.json();
@@ -7,7 +28,7 @@ async function load() {
     const tr = document.createElement('tr');
     const statusClass = s.ready ? 'status-ready' : 'status-down';
     const statusText = s.ready ? 'Online' : 'Offline';
-    tr.innerHTML = `<td>${s.id}</td><td class="${statusClass}">${statusText}</td><td>${s.guilds}</td><td>${s.ping}</td><td>${Math.floor(s.uptime / 1000)}</td>`;
+    tr.innerHTML = `<td>${s.id}</td><td class="${statusClass}">${statusText}</td><td>${s.guilds}</td><td>${s.ping}</td><td>${formatDuration(s.uptime)}</td>`;
     tbody.appendChild(tr);
   });
 }

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
         <th>Status</th>
         <th>Guilds</th>
         <th>Ping</th>
-        <th>Uptime (s)</th>
+        <th>Uptime</th>
       </tr>
     </thead>
     <tbody></tbody>


### PR DESCRIPTION
## Summary
- format shard uptime into human-friendly units (years, months, weeks, days, hours, minutes, seconds)
- update shard status page to show formatted uptime

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afa53430f08327ac5a6f1a4d6f0102